### PR TITLE
feat: 뱃지 기능 및 커스텀 챌린지 조회 기능 추가

### DIFF
--- a/AccountsAPP/models.py
+++ b/AccountsAPP/models.py
@@ -270,3 +270,12 @@ class PasswordResetCode(models.Model):
         indexes = [
             models.Index(fields=['user', 'code']),
         ]
+
+class UserBadge(models.Model):
+    user = models.ForeignKey(CustomUser, on_delete=models.CASCADE, related_name='badges')
+    challenge = models.ForeignKey(CustomChallenge, on_delete=models.CASCADE)
+    badge_image = models.URLField()
+    awarded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('user', 'challenge')

--- a/AccountsAPP/urls.py
+++ b/AccountsAPP/urls.py
@@ -7,7 +7,8 @@ from .views import UserSignupView, UsernameLoginView, TodayAssignedQuestsView, U
     PasswordResetCodeRequestAPIView, PasswordResetWithCodeAPIView, FindUsernameAPIView, GlobalRankingListView, \
     LocalRankingListView, MonthlySuccessDaysAPIView, FCMDeviceManageView, CustomChallengeCreateView, \
     MyCustomChallengeListView, CustomChallengeJoinView, CustomChallengeLeaveView, CustomChallengeDetailView, \
-    CustomChallengeCloseView, CustomChallengeQuestCompleteView, MyEndedCustomChallengeListView
+    CustomChallengeCloseView, CustomChallengeQuestCompleteView, MyEndedCustomChallengeListView, \
+    CustomChallengeQuestResultListView, MyBadgeListView
 from rest_framework_simplejwt.views import TokenRefreshView
 
 urlpatterns = [
@@ -19,6 +20,7 @@ urlpatterns = [
     path('auth/password/reset/confirm-code/', PasswordResetWithCodeAPIView.as_view(), name='password-reset-confirm-code'),
     path('profile/<int:user_id>/', UserProfileView.as_view(), name='user-profile'),
     path('profile/my/', MyPageView.as_view(), name='my-page'),
+    path('profile/my/badges/', MyBadgeListView.as_view(), name='my-badges'),
     path('my-quests/today/', TodayAssignedQuestsView.as_view(), name='today-quests'),
     path('my-quests/<int:assignment_id>/complete/', UserQuestResultCreateView.as_view(), name='quest-complete'),
     path('my-quests/success-days/', MonthlySuccessDaysAPIView.as_view(), name='monthly-success-days'),
@@ -53,4 +55,5 @@ urlpatterns = [
     path('custom-challenge/<int:challenge_id>/close/', CustomChallengeCloseView.as_view(), name='custom-challenge-close'),
     path('custom-challenge/<int:challenge_id>/', CustomChallengeDetailView.as_view(), name='custom-challenge-detail'),
     path('custom-challenge/<int:challenge_id>/quests/<int:quest_id>/complete/', CustomChallengeQuestCompleteView.as_view(), name='custom-challenge-quest-complete'),
+    path('custom-challenge/<int:challenge_id>/quests/<int:quest_id>/results/', CustomChallengeQuestResultListView.as_view(), name='custom-challenge-quest-results')
 ]

--- a/config/celery.py
+++ b/config/celery.py
@@ -22,6 +22,10 @@ app.conf.beat_schedule = {
         'task': 'AccountsAPP.tasks.send_evening_remaining_quests',
         'schedule': crontab(hour=18, minute=0),
     },
+    'award-badges-everyday-1am': {
+        'task': 'your_app_name.tasks.award_challenge_badges',
+        'schedule': crontab(hour=1, minute=0),
+    },
 }
 
 app.conf.beat_schedule.update({
@@ -30,3 +34,5 @@ app.conf.beat_schedule.update({
         'schedule': crontab(hour=12, minute=0),
     },
 })
+
+


### PR DESCRIPTION
1. 커스텀 챌린지 조회 시, 로그인 한 사용자가 리더인지 판별하는 is_leader 필드 추가
2. 유저의 뱃지 이미지를 관리하는 모델 추가
3. 챌린지가 종료되고 다음날 새벽 1시, 전날 완료된 챌린지의 뱃지 부여 스케쥴러 추가 및 비동기처리
4. 유저 뱃지 이미지 목록 가져오는 api